### PR TITLE
Minor quality-of-life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+redis_1
+redis_2
+redis_3

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN cd /usr/local/bin/redis/redis-4.0.6/deps && make hiredis jemalloc linenoise 
 RUN cd /usr/local/bin/redis/redis-4.0.6 && make install
 
 COPY createSentinelConfigFile.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/createSentinelConfigFile.sh
 COPY start_redis /usr/local/bin/
 RUN mkdir -p /etc/redis
 ENTRYPOINT createSentinelConfigFile.sh && start_redis && /bin/bash

--- a/createSentinelConfigFile.sh
+++ b/createSentinelConfigFile.sh
@@ -16,15 +16,15 @@ EOF
 
 
 if [ -n "$SLAVEOF" ]; then
-	redis_cmd="nohup redis-server --bind 0.0.0.0 --port $PORT --slaveof $SLAVEOF --logfile /etc/redis/redis-server.log > /dev/null 2>&1 &"
+	redis_cmd="nohup redis-server --maxmemory 2gb --bind 0.0.0.0 --port $PORT --slaveof $SLAVEOF --logfile /etc/redis/redis-server.log > /dev/null 2>&1 &"
 else
-	redis_cmd="nohup redis-server --bind 0.0.0.0 --port $PORT --logfile /etc/redis/redis-server.log > /dev/null 2>&1 &"
+	redis_cmd="nohup redis-server --maxmemory 2gb --bind 0.0.0.0 --port $PORT --logfile /etc/redis/redis-server.log > /dev/null 2>&1 &"
 fi
 
 if [ -n "$SENTINEL_MASTER_HOST" ]; then
 	echo $redis_cmd$'\n nohup redis-server /etc/redis/sentinel.conf --sentinel  > /dev/null 2>&1 &' > /etc/redis/start_redis
 else
-	echo "$redis_cmd" > /etc/redis/start_redis 
+	echo "$redis_cmd" > /etc/redis/start_redis
 
 fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
         image: centos-redisha
         tty: true
         stdin_open: true
+        volumes:
+          - "./redis_1:/etc/redis"
         ports:
             - '6379:6379'
         command: /bin/bash
@@ -25,7 +27,9 @@ services:
         image: centos-redisha
         tty: true
         stdin_open: true
-        command: /bin/bash 
+        volumes:
+          - "./redis_2:/etc/redis"
+        command: /bin/bash
         networks:
             static-network:
                 ipv4_address: 172.30.0.12
@@ -33,11 +37,11 @@ services:
             - '6380:6379'
         environment:
             - PORT=6379
-            - SLAVEOF=redis_1 6379  
+            - SLAVEOF=redis_1 6379
             - SENTINEL_MASTER_HOST=redis_1 6379
             - SENTINEL_QUORUM=2
             - SENTINEL_DOWN_AFTER=5000
-            - SENTINEL_FAILOVER=5000            
+            - SENTINEL_FAILOVER=5000
         depends_on:
             - redis_1
     redis_3:
@@ -46,7 +50,9 @@ services:
         image: centos-redisha
         tty: true
         stdin_open: true
-        command: /bin/bash 
+        volumes:
+          - "./redis_3:/etc/redis"
+        command: /bin/bash
         networks:
             static-network:
                 ipv4_address: 172.30.0.13
@@ -54,15 +60,15 @@ services:
             - '6381:6379'
         environment:
             - PORT=6379
-            - SLAVEOF=redis_1 6379  
+            - SLAVEOF=redis_1 6379
             - SENTINEL_MASTER_HOST=redis_1 6379
             - SENTINEL_QUORUM=2
             - SENTINEL_DOWN_AFTER=5000
-            - SENTINEL_FAILOVER=5000            
+            - SENTINEL_FAILOVER=5000
         depends_on:
             - redis_1
 networks:
   static-network:
     ipam:
       config:
-        - subnet: 172.30.0.0/16    
+        - subnet: 172.30.0.0/16

--- a/redis_perfomance_tips.sh
+++ b/redis_perfomance_tips.sh
@@ -1,0 +1,4 @@
+#/bin/bash
+
+sysctl vm.overcommit_memory=1
+echo never > /sys/kernel/mm/transparent_hugepage/enabled


### PR DESCRIPTION
* Forceful `chmod +x` on `createSentinelConfigFile.sh` executed on the `Dockerfile`
* Mounting of local volumes (by default on the base folder) to examine logs without entering the containers